### PR TITLE
replace deprecated libcgi-pm-perl w/ CGI::Tiny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Use the official Apache image as the base image
 FROM httpd:latest
 
+# Install cpanm command for Perl module distributions from CPAN
+RUN apt-get update && apt-get install --assume-yes cpanminus
+
 # Enable CGI module
 RUN sed -i '/httpd-ssl.conf/a LoadModule cgi_module modules/mod_cgi.so' /usr/local/apache2/conf/httpd.conf
 
-# Create a directory for CGI scripts
-RUN mkdir -p /usr/local/apache2/cgi-bin
+# Install Perl dependencies
+RUN cpanm --skip-satisfied CGI::Tiny
 
 # Copy the CGI script into the container
 COPY hello.cgi /usr/local/apache2/cgi-bin/
@@ -13,10 +16,7 @@ COPY hello.cgi /usr/local/apache2/cgi-bin/
 # Set permissions for the CGI script
 RUN chmod +x /usr/local/apache2/cgi-bin/hello.cgi
 
-RUN apt update && apt install -y libcgi-pm-perl
-
 # Expose port 80
 EXPOSE 80
 
 CMD ["httpd-foreground"]
-

--- a/hello.cgi
+++ b/hello.cgi
@@ -1,28 +1,25 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
-use strict;
-use warnings;
-use CGI;
+use v5.36;
+use CGI::Tiny;
 
-# Create a new CGI object
-my $cgi = CGI->new();
+cgi {
+  # Get the CGI object
+  my $cgi = $_;
 
-# Get the value of the 'name' parameter
-my $name = $cgi->param('name');
+  # Get the value of the 'name' parameter
+  my $name = $cgi->param('name');
 
-# Default greeting message if 'name' parameter is not specified
-my $greeting = "Hello, CGI!";
+  # Customize greeting message if 'name' parameter is specified
+  my $greeting = CGI::Tiny::escape_html( 'Hello, ' . ( $name || 'CGI' ) . '!' );
 
-# Customize greeting message if 'name' parameter is specified
-if ($name) {
-    $greeting = "Hello, $name!";
+  # Print HTML response
+  $cgi->render( html => <<~"HTML");
+    <html>
+      <head><title>Hello CGI</title></head>
+      <body>
+        <h1>$greeting</h1>
+      </body>
+    </html>
+    HTML
 }
-
-# Print HTTP header with content type
-print $cgi->header('text/html');
-
-# Print HTML response
-print "<html><head><title>Hello CGI</title></head><body>";
-print "<h1>$greeting</h1>";
-print "</body></html>";
-


### PR DESCRIPTION
Per the [CGI.pm documentation on CPAN][1], the module "is no longer
considered good practice for developing web applications, **including**
quick prototyping and small web scripts."

This replaces CGI.pm with [CGI::Tiny][2] from CPAN, one of the
recommendations from [CGI::Alternatives][3]. There is also a minor
code change to take advantage of Perl's indented here-document syntax
for the embedded HTML.

[1]: <https://metacpan.org/pod/CGI#CGI.pm-HAS-BEEN-REMOVED-FROM-THE-PERL-CORE>
[2]: <https://metacpan.org/pod/CGI::Tiny>
[3]: <https://metacpan.org/pod/CGI::Alternatives>